### PR TITLE
interface_meta 1.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,22 +11,28 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  skip: True  # [py<37]
 
 requirements:
   host:
     - pip
-    - python >=3.7
-    - poetry
+    - python
+    - poetry 1.4.0
     - poetry-dynamic-versioning
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
+    - python
 
 test:
   imports:
     - interface_meta
     - interface_meta.utils
+  requires: 
+    - pip
+  commands: 
+    - pip check
 
 about:
   home: https://github.com/matthewwardrop/interface_meta
@@ -34,6 +40,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: '`interface_meta` provides a convenient way to expose an extensible API with enforced method signatures and consistent documentation.'
+  description: '`interface_meta` provides a convenient way to expose an extensible API with enforced method signatures and consistent documentation.'
   doc_url: https://github.com/matthewwardrop/interface_meta
   dev_url: https://github.com/matthewwardrop/interface_meta
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - pip
     - python
-    - poetry 1.4.0
+    - poetry-core 1.5.1
     - poetry-dynamic-versioning
     - setuptools
     - wheel


### PR DESCRIPTION
Changelog: https://github.com/matthewwardrop/interface_meta/releases
License: https://github.com/matthewwardrop/interface_meta/blob/v1.3.0/LICENSE
Requirements: https://github.com/matthewwardrop/interface_meta/blob/v1.3.0/pyproject.toml

Actions:
1. Apply an initial **percy** [patch](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/test_patch.json) and run locally a [script](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/updater_standalone.py) to: 
  - Remove `noarch python`
  - Skip `py<37`
  - Add flags `--no-deps --no-build-isolation` to `script`
  - Add missing `setuptools` and `wheel` to `host`
  - Fix `python` in `host` and `run`
2. Add `poetry-core` pin **1.5.1** (note that 1.4.0 hasn't py311 support on ppc64le)
3. Add `description`

Notes:
- `formulaic` requires it https://github.com/AnacondaRecipes/formulaic-feedstock/blob/d669d6055b51a38bc1e0b7bcd4471e0e10cbc76a/recipe/meta.yaml#L28