### PR TITLE
interface_meta 2.0.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "interface_meta" %}
-{% set version = "1.3.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,19 +7,19 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8a4493f8bdb73fb9655dcd5115bc897e207319e36c8835f39c516a2d7e9d79a1
+  sha256: 902bd9a95a12f195f15753a1080075d4eca7a2cb934fac7ac03c9e362b50796a
 
 build:
-  number: 2
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<37]
+  skip: True  # [py<310]
 
 requirements:
   host:
     - pip
     - python
-    - poetry-core >=1.0.0
-    - poetry-dynamic-versioning
+    - hatchling
+    - hatch-vcs
   run:
     - python
 


### PR DESCRIPTION
interface_meta 2.0.1 

**Destination channel:** Defaults

### Links

- [PKG-14491]
- dev_url:        https://github.com/matthewwardrop/interface_meta/tree/v2.0.1
- conda_forge:    https://github.com/conda-forge/interface_meta-feedstock
- pypi:           https://pypi.org/project/interface_meta/2.0.1
- pypi inspector: https://inspector.pypi.io/project/interface_meta/2.0.1

### Explanation of changes:

- new version number


[PKG-14491]: https://anaconda.atlassian.net/browse/PKG-14491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ